### PR TITLE
feat: change CLI name and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,22 @@ TicketPlease is a command-line tool that helps developers and engineers generate
 - **Interactive Guided Flow**: Step-by-step questions to collect all necessary information
 - **AI-Powered Content Generation**: Uses LLMs to process user responses and generate complete, well-formatted descriptions
 - **Multi-Platform Support**: Generates output in Markdown for GitHub or Jira text markup format
-- **Guided Initial Setup**: Onboarding wizard for API key and AI model configuration
+- **Configurable Setup**: Interactive wizard guides you through API key and AI model configuration when running `tk config` for the first time or if no configuration file exists
 - **Persistent Preferences**: Saves user preferences for language, file paths, and platform
 - **Iterative Refinement**: Allows users to request modifications to generated text
 - **Multilingual Support**: Accepts input in user's language and generates output in configured language
 - **Clipboard Integration**: Automatically copies final text to clipboard for immediate use
+
+## LLM Model Configuration
+
+TicketPlease leverages [LiteLLM](https://litellm.ai/) to provide a flexible and configurable way to interact with various Large Language Model (LLM) providers and models. This allows you to choose your preferred AI provider (e.g., OpenAI, Anthropic, Google, OpenRouter) and the specific model you wish to use.
+
+During the `tk config` setup, you will be presented with a curated list of commonly used and supported models for your chosen provider. This list is dynamically fetched via LiteLLM.
+
+**Custom Model Specification:**
+If your desired model is supported by LiteLLM but does not appear in the default list provided during configuration, you can still specify it. Simply select the "Specify custom model" option (or similar, depending on the provider) in the wizard, and then manually enter the exact model name. TicketPlease will attempt to use this model via LiteLLM.
+
+This flexibility ensures that you can always utilize the latest or most suitable LLM for your needs, even if it's not explicitly listed by default.
 
 ## Installation
 
@@ -49,30 +60,34 @@ This will install all dependencies and set up pre-commit hooks automatically.
 
 ### Basic Usage
 
-```bash
-# Start the interactive task generation flow
-tkp
-
-# Show version
-tkp --version
-
-# Show help
-tkp --help
-
-# Configure settings
-tkp config
-```
+| Type    | Command/Option       | Description                                     |
+|:--------|:---------------------|:------------------------------------------------|
+| Command | `tk please`          | Start the interactive task generation flow      |
+| Command | `tk config`          | Configure your TicketPlease settings           |
+| Command | `tk`                 | Show help (default behavior without arguments) |
+| Option  | `tk --version`, `-v` | Show version and exit                           |
+| Option  | `tk --help`          | Show this message and exit                      |
 
 ### Configuration
 
-On first use, TicketPlease will guide you through the initial setup:
+To configure TicketPlease, run the configuration command:
+
+```bash
+tk config
+```
+
+This will guide you through the setup process:
 
 1. Choose your AI provider (OpenAI, Anthropic, Gemini, OpenRouter)
 2. Enter your API key
 3. Select an AI model
 4. Configure default preferences
 
+Once configured for the first time, you can update your preferences at any point by running `tk config` again. Additionally, many of these preferences (like output language or platform) can be overridden for individual tasks during the interactive task generation flow (`tk please`), providing maximum flexibility.
+
 Configuration is stored in `~/.config/ticketplease/config.toml`.
+
+After configuration, you can start creating tasks with `tk please`.
 
 ## Development
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,7 +2,8 @@
 
 ## 1. Overview del Proyecto
 
-**Nombre provisional:** TicketPlease (tkp)
+**Nombre provisional:** TicketPlease (tk);
+
 
 **Elevator Pitch:** TicketPlease es una herramienta de línea de comandos (CLI) desarrollada en Python que utiliza IA para ayudar a desarrolladores e ingenieros a generar descripciones de tareas estandarizadas y de alta calidad para plataformas como Jira y GitHub. A través de un flujo interactivo, la herramienta recopila los requisitos clave y produce un texto formateado listo para ser copiado y pegado, acelerando el proceso de creación de tickets y mejorando la claridad de las tareas.
 
@@ -112,18 +113,18 @@ h3. Definition of Done
 
 ### 5.1. Primer Uso (Onboarding)
 
-- El usuario ejecuta ticketplease.
+- El usuario ejecuta `tk config`.
 - La herramienta detecta que no existe ~/.config/ticketplease/config.toml.
 - Inicia el asistente de configuración:
   - Pregunta 1: "Elige tu proveedor de IA: [OpenAI, Anthropic, Gemini, OpenRouter]".
   - Pregunta 2: "Por favor, introduce tu API Key".
   - Pregunta 3: "Elige un modelo de la lista: [gpt-4o-mini, claude-3-sonnet..., etc.]" (La lista se obtiene vía litellm).
   - Guarda la configuración en el archivo config.toml.
-  - Procede al flujo de uso regular.
+  - El usuario puede ejecutar `tk please` para crear tareas.
 
 ### 5.2. Uso Regular
 
-- El usuario ejecuta ticketplease en su terminal (comando tkp).
+- El usuario ejecuta `tk please` en su terminal.
 - La herramienta carga las preferencias desde config.toml.
 - Pregunta 1: ¿Qué hay que hacer? (Describe la tarea brevemente)
 - Pregunta 2: Plataforma de destino: [GitHub | Jira] (pre-seleccionada según la preferencia).
@@ -142,13 +143,17 @@ h3. Definition of Done
 
 ```bash
 # Inicia el flujo interactivo principal para crear una nueva tarea
-\$ tkp
+\$ tk please
+
+# Muestra la ayuda (comportamiento por defecto sin argumentos)
+\$ tk
 
 # Muestra la versión de la herramienta
-\$ tkp --version
+\$ tk --version
+\$ tk -v
 
 # Permite gestionar la configuración
-\$ tkp config
+\$ tk config
 # Opciones interactivas para:
 # - Ver la configuración actual
 # - Cambiar la API Key o el proveedor

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,7 +2,7 @@
 
 ## 1. Overview del Proyecto
 
-**Nombre provisional:** TicketPlease (tk);
+**Nombre provisional:** TicketPlease (tk)
 
 
 **Elevator Pitch:** TicketPlease es una herramienta de línea de comandos (CLI) desarrollada en Python que utiliza IA para ayudar a desarrolladores e ingenieros a generar descripciones de tareas estandarizadas y de alta calidad para plataformas como Jira y GitHub. A través de un flujo interactivo, la herramienta recopila los requisitos clave y produce un texto formateado listo para ser copiado y pegado, acelerando el proceso de creación de tickets y mejorando la claridad de las tareas.

--- a/docs/tech-specs.md
+++ b/docs/tech-specs.md
@@ -1,6 +1,6 @@
 # Especificaciones Técnicas
 
-Este documento define las directrices técnicas, los estándares de codificación y el flujo de trabajo de desarrollo para el proyecto Ticket Please. El objetivo es garantizar un código consistente, legible, mantenible y de alta calidad. El nombre del paquete en PyPI será ticketplease y el comando de la CLI será tkp.
+Este documento define las directrices técnicas, los estándares de codificación y el flujo de trabajo de desarrollo para el proyecto Ticket Please. El objetivo es garantizar un código consistente, legible, mantenible y de alta calidad. El nombre del paquete en PyPI será ticketplease y el comando de la CLI será tk.
 
 ## Gestión de Dependencias
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ types-pyperclip = "^1.9.0.20250218"
 types-toml = "^0.10.8.20240310"
 
 [tool.poetry.scripts]
-tkp = "cli.main:app"
+tk = "cli.main:app"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -3,12 +3,12 @@
 import typer
 from rich.console import Console
 
-from ticketplease.main import run_config
+from ticketplease.main import run_config, run_task_generation
 
 from . import __version__
 
 app = typer.Typer(
-    name="tkp",
+    name="tk",
     help="CLI assistant for generating task descriptions using AI",
     add_completion=False,
 )
@@ -16,22 +16,29 @@ console = Console()
 
 
 @app.command()
-def version() -> None:
-    """Show the version of TicketPlease."""
-    console.print(f"TicketPlease version {__version__}")
+def please() -> None:
+    """Start the interactive task generation flow."""
+    run_task_generation()
 
 
 @app.command()
 def config() -> None:
-    """Modify your TicketPlease configuration."""
+    """Configure your TicketPlease settings."""
     run_config(is_update=True)
 
 
 @app.callback(invoke_without_command=True)
-def main(ctx: typer.Context) -> None:
-    """Start the interactive task generation flow."""
+def main(
+    ctx: typer.Context,
+    version: bool = typer.Option(False, "--version", "-v", help="Show version and exit"),
+) -> None:
+    """Show help when no command is provided."""
+    if version:
+        console.print(f"TicketPlease version {__version__}")
+        raise typer.Exit()
+
     if ctx.invoked_subcommand is None:
-        run_config(is_update=False)
+        console.print(ctx.get_help())
 
 
 if __name__ == "__main__":

--- a/src/ticketplease/main.py
+++ b/src/ticketplease/main.py
@@ -31,16 +31,15 @@ def run_config(is_update: bool = False) -> None:
             console.print(f"\n❌ Configuration error: {e}")
             return
 
-        # After successful initial setup, start task generation
-        if not is_update:
-            run_task_generation()
+        # After successful initial setup, inform user about next steps
+        console.print()
+        console.print("✅ Configuration completed successfully!")
+        console.print()
+        console.print("You can now create tasks with [bold cyan]tk please[/bold cyan]")
+        console.print()
         return
 
-    # If this is not an update, start task generation
-    if not is_update:
-        run_task_generation()
-        return
-
+    # Configuration exists, run update
     try:
         wizard = ConfigWizard()
         wizard.run_update()
@@ -55,5 +54,16 @@ def run_config(is_update: bool = False) -> None:
 def run_task_generation() -> None:
     """Run the task generation flow."""
     config = Config()
+
+    # Check if configuration exists
+    if config.is_first_run():
+        console.print("[red]❌ No configuration found.[/red]")
+        console.print()
+        console.print(
+            "Please run [bold cyan]tk config[/bold cyan] first to set up your preferences."
+        )
+        console.print()
+        return
+
     generator = TaskGenerator(config)
     generator.generate_task()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -31,6 +31,7 @@ class TestIntegration:
         """Test successful task generation flow."""
         # Setup mocks
         mock_config = MagicMock()
+        mock_config.is_first_run.return_value = False  # Configuration exists
         mock_config_class.return_value = mock_config
 
         mock_generator = MagicMock()
@@ -42,6 +43,7 @@ class TestIntegration:
 
         # Verify calls
         mock_config_class.assert_called_once()
+        mock_config.is_first_run.assert_called_once()
         mock_generator_class.assert_called_once_with(mock_config)
         mock_generator.generate_task.assert_called_once()
 
@@ -51,6 +53,7 @@ class TestIntegration:
         """Test task generation flow when generation fails."""
         # Setup mocks
         mock_config = MagicMock()
+        mock_config.is_first_run.return_value = False  # Configuration exists
         mock_config_class.return_value = mock_config
 
         mock_generator = MagicMock()
@@ -62,8 +65,28 @@ class TestIntegration:
 
         # Verify calls
         mock_config_class.assert_called_once()
+        mock_config.is_first_run.assert_called_once()
         mock_generator_class.assert_called_once_with(mock_config)
         mock_generator.generate_task.assert_called_once()
+
+    @patch("ticketplease.main.Config")
+    @patch("ticketplease.main.console")
+    def test_run_task_generation_no_config(self, mock_console, mock_config_class):
+        """Test task generation flow when no configuration exists."""
+        # Setup mocks
+        mock_config = MagicMock()
+        mock_config.is_first_run.return_value = True  # No configuration
+        mock_config_class.return_value = mock_config
+
+        # Run the function
+        run_task_generation()
+
+        # Verify calls
+        mock_config_class.assert_called_once()
+        mock_config.is_first_run.assert_called_once()
+
+        # Verify console messages were printed
+        assert mock_console.print.call_count >= 3  # Should print error and instruction messages
 
     @patch("ticketplease.generator.TaskDataCollector")
     @patch("ticketplease.generator.AIService")
@@ -73,7 +96,6 @@ class TestIntegration:
     def test_complete_flow_manual_input(
         self,
         mock_select,
-        mock_text,
         mock_copy,
         mock_ai_service_class,
         mock_collector_class,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -91,7 +91,6 @@ class TestIntegration:
     @patch("ticketplease.generator.TaskDataCollector")
     @patch("ticketplease.generator.AIService")
     @patch("ticketplease.generator.copy_to_clipboard")
-    @patch("questionary.text")
     @patch("questionary.select")
     def test_complete_flow_manual_input(
         self,

--- a/tests/test_ticketplease.py
+++ b/tests/test_ticketplease.py
@@ -5,21 +5,26 @@ from unittest.mock import patch
 from ticketplease.main import run_config
 
 
-def test_run_wizard_with_existing_config():
-    """Test that run_wizard does nothing when config already exists."""
+def test_run_config_with_existing_config():
+    """Test that run_config runs update wizard when config exists."""
     with (
-        patch("ticketplease.main.console") as mock_console,
         patch("ticketplease.main.Config") as mock_config_class,
+        patch("ticketplease.main.ConfigWizard") as mock_wizard_class,
     ):
         # Mock config to simulate existing valid configuration
         mock_config = mock_config_class.return_value
         mock_config.is_first_run.return_value = False
         mock_config.is_configured.return_value = True
 
-        run_config(is_update=False)
+        # Mock wizard
+        mock_wizard = mock_wizard_class.return_value
 
-        # Verify that no console.print was called (no wizard needed)
-        assert mock_console.print.call_count == 0
+        # Call with is_update=True (this is what happens when user runs 'tk config')
+        run_config(is_update=True)
+
+        # Verify that wizard update was called
+        mock_wizard_class.assert_called_once()
+        mock_wizard.run_update.assert_called_once()
 
 
 def test_run_wizard_first_run():


### PR DESCRIPTION
- Changes CLI name: from tkp to tk.
- Adds a new command "please" for generating tasks.
- The configuration wizard is now presented when the "config" command is executed.
- CLI executed without commands or arguments shows the help by default.